### PR TITLE
Require more than just the country category

### DIFF
--- a/importer/make_NordicMuseum_info.py
+++ b/importer/make_NordicMuseum_info.py
@@ -553,6 +553,10 @@ class NMItem(object):
                 commonscats.append(mapped_data.get('commonscat'))
             labels[geo_type] = data.get('label')
 
+        # just knowing country is pretty bad
+        if len(commonscats) <= 1:
+            self.meta_cats.add('needing categorisation (place)')
+
         return {
             'role': role,
             'wd': wikidata,


### PR DESCRIPTION
If depicted place data is present require that it generates more
than just one (likely the country) commonscat entry. Otherwise add
a maintenance category.