### PR TITLE
Less crash more skip

### DIFF
--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -246,11 +246,13 @@ class DiMuHarvester(object):
         # event_wrapper contains info about both creator and creation date
         self.parse_event_wrap(data, raw_data.get('eventWrap'))
 
+        # tags are user entered (but approved) keywords
+        self.parse_tags(data, raw_data.get('tags'))
+
         # not implemented yet
         data['title'] = self.not_implemented_yet_waring(raw_data, 'titles')  # titles contains titles in multiple languages (NOR as default)  # noqa
         data['coordinate'] = self.not_implemented_yet_waring(
             raw_data, 'coordinates')
-        data['tags'] = self.not_implemented_yet_waring(raw_data, 'tags')
         data['inscriptions'] = self.not_implemented_yet_waring(
             raw_data, 'inscriptions')
         data['subjects_2'] = self.not_implemented_yet_waring(  # subjects also exist within motif  # noqa
@@ -266,6 +268,19 @@ class DiMuHarvester(object):
             raw_data, 'material')
 
         return data
+
+    def parse_tags(self, data, raw_tags):
+        """
+        Parse data on user entered tags.
+
+        :param data: the object in which to store the parsed components
+        :param tags: list of tag.objects
+        """
+        if raw_tags:
+            tags = set()
+            for tag in raw_tags:
+                tags.add(tag['name'])
+            data['tags'] = list(tags)
 
     def parse_motif(self, data, motif_data):
         """

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -106,12 +106,11 @@ class DiMuHarvester(object):
 
         return data.get('response')
 
-    def load_collection(self, idno, strict=False):
+    def load_collection(self, idno):
         """
         Process the collection/folder with the given id.
 
         :param idno: either the uuid or uniqueId for the folder
-        :param strict: if True then crash on unrecognized entries
         """
         self.folder_uuid = self.load_collection_object(idno)
 
@@ -141,10 +140,10 @@ class DiMuHarvester(object):
                         continue
                     self.process_single_object(item.get('artifact.uuid'))
                 else:
-                    if not strict:
-                        continue
-                    raise pywikibot.Error(
-                        'Unexpected aritfact type: {}'.format(item_type))
+                    pywikibot.warning(
+                        '{uuid}: The artifact type {typ} is not yet supported.'
+                        ' Skipping!'.format(
+                            uuid=item.get('artifact.uuid'), typ=item_type))
             if not stop:
                 start += num_hits
                 search_data = self.get_search_record_from_url(
@@ -250,21 +249,21 @@ class DiMuHarvester(object):
         self.parse_tags(data, raw_data.get('tags'))
 
         # not implemented yet
-        data['title'] = self.not_implemented_yet_waring(raw_data, 'titles')  # titles contains titles in multiple languages (NOR as default)  # noqa
-        data['coordinate'] = self.not_implemented_yet_waring(
+        data['title'] = self.not_implemented_yet_warning(raw_data, 'titles')  # titles contains titles in multiple languages (NOR as default)  # noqa
+        data['coordinate'] = self.not_implemented_yet_warning(
             raw_data, 'coordinates')
-        data['inscriptions'] = self.not_implemented_yet_waring(
+        data['inscriptions'] = self.not_implemented_yet_warning(
             raw_data, 'inscriptions')
-        data['subjects_2'] = self.not_implemented_yet_waring(  # subjects also exist within motif  # noqa
+        data['subjects_2'] = self.not_implemented_yet_warning(  # subjects also exist within motif  # noqa
             raw_data, 'subjects')
-        data['names'] = self.not_implemented_yet_waring(raw_data, 'names')
-        data['measures'] = self.not_implemented_yet_waring(
+        data['names'] = self.not_implemented_yet_warning(raw_data, 'names')
+        data['measures'] = self.not_implemented_yet_warning(
             raw_data, 'measures')
-        data['classification'] = self.not_implemented_yet_waring(
+        data['classification'] = self.not_implemented_yet_warning(
             raw_data, 'classifications')
-        data['technique'] = self.not_implemented_yet_waring(
+        data['technique'] = self.not_implemented_yet_warning(
             raw_data, 'technique')
-        data['material'] = self.not_implemented_yet_waring(
+        data['material'] = self.not_implemented_yet_warning(
             raw_data, 'material')
 
         return data
@@ -609,7 +608,7 @@ class DiMuHarvester(object):
         for uuid in uuid_list:
             self.process_single_object(uuid)
 
-    def not_implemented_yet_waring(self, raw_data, method):
+    def not_implemented_yet_warning(self, raw_data, method):
         """Raise a pywikibot warning that a method has not been implemented."""
         if raw_data.get(method):
             pywikibot.warning(

--- a/importer/DiMuMappingUpdater.py
+++ b/importer/DiMuMappingUpdater.py
@@ -109,7 +109,10 @@ class DiMuMappingUpdater(object):
             data = v.get('data')
             entry = {}
             entry['name'] = data.get('name')
-            entry['more'] = 'Roles: {}'.format('/'.join(data.get('roles')))
+            entry['more'] = ''
+            roles = list(filter(None, data.get('roles')))
+            if roles:
+                entry['more'] = 'Roles: {}'.format('/'.join(roles))
             if data.get('k_nav'):
                 knav_id = data.get('k_nav')
                 if knav_id in self.kulturnav_hits:
@@ -128,17 +131,20 @@ class DiMuMappingUpdater(object):
         """Go through the harvest data breaking out data needing mapping."""
         for key, image in harvest_data.items():
             self.subjects_to_map.update(image.get('subjects'))
+            self.subjects_to_map.update(image.get('tags'))
 
             if image.get('default_copyright'):
-                for person in image.get('default_copyright').get('persons'):
-                    self.parse_person(person)
+                if image.get('default_copyright').get('persons'):
+                    for person in image.get('default_copyright').get('persons'):
+                        self.parse_person(person)
             if image.get('copyright'):
                 for person in image.get('copyright').get('persons'):
                     self.parse_person(person)
 
             self.parse_place(image.get('depicted_place'))
-            for place in image.get('description_place').values():
-                self.parse_place(place)
+            if image.get('description_place'):
+                for place in image.get('description_place').values():
+                    self.parse_place(place)
             if image.get('creation'):
                 for place in image.get('creation').get('related_places'):
                     self.parse_place(place)
@@ -154,6 +160,8 @@ class DiMuMappingUpdater(object):
     #        Risk of mismatches?
     def parse_place(self, place_data):
         """Gather and combine place data."""
+        if not place_data:
+            return
         del place_data['role']
         place_data.update(place_data.pop('other'))
         for typ, value in place_data.items():

--- a/importer/make_NordicMuseum_info.py
+++ b/importer/make_NordicMuseum_info.py
@@ -391,6 +391,10 @@ class NMItem(object):
             original_desc += '\n<br />{label}: {words}'.format(
                 label=helpers.bolden('Ämnesord'),
                 words='; '.join(self.subjects))
+        if self.tags:
+            original_desc += '\n<br />{label}: {words}'.format(
+                label=helpers.bolden('Nyckelord'),
+                words='; '.join(self.subjects))
 
         role_dict = {
             'depicted_place': 'Avbildad plats',
@@ -609,11 +613,15 @@ class NMItem(object):
 
         :param cache: cache for category existence
         """
-        if self.subjects_2 or self.tags:
-            raise NotImplementedError
+        all_keywords = set()
+        all_keywords.update(self.subjects)
+        if self.tags:
+            all_keywords.update(self.tags)
+        if self.subjects_2:
+            all_keywords.update(self.subjects_2)
         keyword_map = self.nm_info.mappings['keywords']
 
-        for keyword in self.subjects:
+        for keyword in all_keywords:
             if keyword not in keyword_map:
                 continue
             for cat in keyword_map[keyword]:


### PR DESCRIPTION
Raise warning instead of crashing for unknown artifact types (`Thing`).

Also:
* Support `tags`.
** Mapped together with `subject` but harvested separately.
** For commons purposes they are combined in keyword generation but
separated under "original description".
* More flexibility during mapping generation.