### PR TITLE
Upload the `Nyfotograferad dräkt` collection

### DIFF
--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -76,15 +76,20 @@ class DiMuHarvester(object):
         # not present in object entry, but it's needed if we want to link
         # to the exhibition from Commons
 
-    def save_data(self, filename=None):
-        """Dump data as json blob."""
-        filename = filename or self.settings.get('harvest_file')
+    def sort_data(self, sorting_key):
+        """Sort downloaded data by selected key."""
         sorted_data = {}
         sorted_keys = sorted(
             self.data.keys(), key=lambda y: (self.data[y]['glam_id']))
         for key in sorted_keys:
-            sorted_data[key] = self.data[key]
-        common.open_and_write_file(filename, self.data, as_json=True)
+                sorted_data[key] = self.data[key]
+        return sorted_data
+
+    def save_data(self, filename=None):
+        """Dump data as json blob."""
+        filename = filename or self.settings.get('harvest_file')
+        sorted_data = self.sort_data('glam_id')
+        common.open_and_write_file(filename, sorted_data, as_json=True)
         pywikibot.output('{0} created'.format(filename))
 
     def get_search_record_from_url(self, query, only_folder=False, start=None):

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -79,6 +79,11 @@ class DiMuHarvester(object):
     def save_data(self, filename=None):
         """Dump data as json blob."""
         filename = filename or self.settings.get('harvest_file')
+        sorted_data = {}
+        sorted_keys = sorted(
+            self.data.keys(), key=lambda y: (self.data[y]['glam_id']))
+        for key in sorted_keys:
+            sorted_data[key] = self.data[key]
         common.open_and_write_file(filename, self.data, as_json=True)
         pywikibot.output('{0} created'.format(filename))
 

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -80,7 +80,7 @@ class DiMuHarvester(object):
         """Sort downloaded data by selected key."""
         sorted_data = {}
         sorted_keys = sorted(
-            self.data.keys(), key=lambda y: (self.data[y]['glam_id']))
+            self.data.keys(), key=lambda y: (self.data[y][sorting_key]))
         for key in sorted_keys:
                 sorted_data[key] = self.data[key]
         return sorted_data

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -66,6 +66,8 @@ class DiMuHarvester(object):
 
     def __init__(self, options):
         """Initialise a harvester object for a DigitaltMuseum harvest."""
+        if not os.path.exists(CACHE_DIR):
+            os.makedirs(CACHE_DIR)  # Create directory for cache if needed
         self.data = {}  # data container for harvested info
         self.settings = options
         self.log = common.LogFile('', self.settings.get('harvest_log_file'))
@@ -235,12 +237,17 @@ class DiMuHarvester(object):
         url = 'http://api.dimu.org/artifact/uuid/{}'.format(uuid)
 
         try:
+            filepath = os.path.join(CACHE_DIR, uuid + ".json")
             if self.settings["cache"]:
                 print("Loading {} from local cache".format(uuid))
-                filepath = os.path.join(CACHE_DIR, uuid + ".json")
                 data = common.open_and_read_file(filepath, as_json=True)
             else:
                 data = get_json_from_url(url)
+                # try:
+                #     open(filepath, 'r')
+                # except FileNotFoundError:
+                #     open(filepath, 'w')
+                common.open_and_write_file(filepath, data, as_json=True)
             # print(data)
         except requests.HTTPError as e:
             error_message = '{0}: {1}'.format(e, url)

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -253,8 +253,14 @@ class DiMuHarvester(object):
                             raw_data.get('identifier').get('id'))]
         data['type'] = raw_data.get('artifactType')
 
-        data['filename'] = self.parse_alternative_id(
+        alternative_ids = self.parse_alternative_id(
             raw_data.get('alternativeIdentifiers'))
+
+        if alternative_ids:
+            if alternative_ids["type"] == "Filnamn":
+                data['filename'] = alternative_ids["identifier"]
+            elif alternative_ids["type"] == "Insamlingsnr":
+                data['insamlingsnr'] = alternative_ids["identifier"]
 
         # copyright can exists on both object and image level
         data['default_copyright'] = self.parse_license_info(
@@ -529,19 +535,20 @@ class DiMuHarvester(object):
     def parse_alternative_id(self, alt_id_data):
         """Parse data about alternative identifiers."""
         problem = None
+        accepted_ids = ["Insamlingsnr", "Filnamn"]
         if alt_id_data:
             # unclear how to handle multiple such or non-filename such
             if len(alt_id_data) > 1:
                 problem = (
                     '{}: Found multiple alternative identifiers, '
                     'unsure how to deal with this.'.format(self.active_uuid))
-            elif alt_id_data[0].get('type') != 'Filnamn':
+            elif alt_id_data[0].get('type') not in accepted_ids:
                 problem = (
                     '{0}: Found an unexpected alternative identifiers type '
                     '("{1}"), unsure how to deal with this.'.format(
                         self.active_uuid, alt_id_data[0].get('type')))
             else:
-                return alt_id_data[0].get('identifier')
+                return alt_id_data[0]
 
         if problem:
             self.verbose_output(problem)

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -296,13 +296,16 @@ class DiMuHarvester(object):
         # parse technique
         self.parse_technique(data, raw_data.get('technique'))
 
+        # parse title
+        self.parse_title(data, raw_data.get('title'))
+
         # parse inscriptions
         self.parse_inscriptions(data, raw_data.get('inscriptions'))
 
         # tags are user entered (but approved) keywords
         self.parse_tags(data, raw_data.get('tags'))
+
         # not implemented yet
-        data['title'] = self.not_implemented_yet_warning(raw_data, 'titles')  # titles contains titles in multiple languages (NOR as default)  # noqa
         data['coordinate'] = self.not_implemented_yet_warning(
             raw_data, 'coordinates')
         data['names'] = self.not_implemented_yet_warning(raw_data, 'names')
@@ -310,6 +313,21 @@ class DiMuHarvester(object):
             raw_data, 'classifications')
 
         return data
+
+    def parse_title(self, data, raw_title):
+        """
+        Parse 'title' field.
+
+        Implemented so that objects without
+        a description can get a meaningful file name.
+        E.g.
+        http://api.dimu.org/artifact/uuid/7F78B868-EC5E-4572-BDF5-C478F3C57966
+
+        :param data: the object in which to store the parsed components
+        :param raw_title: content of 'title' key
+        """
+        if raw_title:
+            data['title'] = raw_title.strip()
 
     def parse_tags(self, data, raw_tags):
         """

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -656,11 +656,12 @@ class DiMuHarvester(object):
                 person = self.parse_person(related_p[0])
                 data["creator"].append(person)
         elif art_type == "Thing":  # this is a thing
-            raw_person = raw_data["media"]["pictures"][0]["photographer"]
-            person_name = helpers.flip_name(raw_person)
-            data["creator"].append({"id": person_name,
-                                    "role": "creator",
-                                    "name": person_name})
+            raw_person = raw_data["media"]["pictures"][0].get("photographer")
+            if raw_person:
+                person_name = helpers.flip_name(raw_person)
+                data["creator"].append({"id": person_name,
+                                        "role": "creator",
+                                        "name": person_name})
 
     def parse_event_wrap(self, data, event_wrap_data):
         """

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -243,12 +243,7 @@ class DiMuHarvester(object):
                 data = common.open_and_read_file(filepath, as_json=True)
             else:
                 data = get_json_from_url(url)
-                # try:
-                #     open(filepath, 'r')
-                # except FileNotFoundError:
-                #     open(filepath, 'w')
                 common.open_and_write_file(filepath, data, as_json=True)
-            # print(data)
         except requests.HTTPError as e:
             error_message = '{0}: {1}'.format(e, url)
             self.log.write(error_message)

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -643,8 +643,8 @@ class DiMuHarvester(object):
         """Parse creator info for different object types."""
         data["creator"] = []
         art_type = raw_data["artifactType"]
-        events = raw_data["eventWrap"]["events"]
-        if art_type == "Photograph":
+        events = raw_data["eventWrap"].get("events")
+        if events and art_type == "Photograph":
             ev_type = events[0].get("eventType")
             if ev_type == "Produktion":  # this is an artwork
                 person = self.parse_person(
@@ -698,13 +698,14 @@ class DiMuHarvester(object):
 
         # store non-creation events but log the types
         data['events'] = []
-        for event in event_wrap_data.get('events'):
-            event_type = event.get('eventType')
-            if event_type not in creation_types:
-                self.log.write(
-                    '{}: found a new event type "{}".'.format(
-                        self.active_uuid, event_type))
-                data['events'].append(self.parse_event(event))
+        if event_wrap_data.get('events'):
+            for event in event_wrap_data.get('events'):
+                event_type = event.get('eventType')
+                if event_type not in creation_types:
+                    self.log.write(
+                        '{}: found a new event type "{}".'.format(
+                            self.active_uuid, event_type))
+                    data['events'].append(self.parse_event(event))
 
         # store Historik
         data['history'] = None

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -324,13 +324,14 @@ class DiMuHarvester(object):
         if not data.get("subjects"):
             data["subjects"] = []
         subjects = set()
-        for subject in subjects_data:
-            if subject.get('nameType') == "subject":
-                subjects.add(subject.get('name'))
-            else:
-                self.log.write(
-                    '{}: had an unexpected subject name type "{}".'.format(
-                        self.active_uuid, subject.get('nameType')))
+        if subjects_data:
+            for subject in subjects_data:
+                if subject.get('nameType') == "subject":
+                    subjects.add(subject.get('name'))
+                else:
+                    self.log.write(
+                        '{}: had an unexpected subject name type "{}".'.format(
+                            self.active_uuid, subject.get('nameType')))
         new_subjects = data.get("subjects") + list(subjects)
         data['subjects'] = new_subjects
 

--- a/importer/DiMuHarvester.py
+++ b/importer/DiMuHarvester.py
@@ -17,6 +17,7 @@ import batchupload.common as common
 import batchupload.helpers as helpers
 
 SETTINGS_DIR = "settings"
+CACHE_DIR = "cache"
 SETTINGS = "settings.json"
 LOGFILE = 'dimu_harvest.log'
 HARVEST_FILE = 'dimu_harvest_data.json'

--- a/importer/DiMuMappingUpdater.py
+++ b/importer/DiMuMappingUpdater.py
@@ -179,6 +179,8 @@ class DiMuMappingUpdater(object):
                     self.parse_person(person)
             if image.get("photographer"):
                 self.parse_person(image.get("photographer"))
+            if image.get("creator"):
+                self.parse_person(image.get("creator"))
 
     # @todo: is connection between place levels broken by this?
     #        Risk of mismatches?
@@ -195,6 +197,8 @@ class DiMuMappingUpdater(object):
 
     def parse_person(self, person_data):
         """Gather and combine person data."""
+        if type(person_data) is list:
+            person_data = person_data[0]
         idno = person_data.pop('id')
         role = person_data.pop('role')
         if idno not in self.people_to_map:

--- a/importer/make_glam_info.py
+++ b/importer/make_glam_info.py
@@ -431,6 +431,7 @@ class GLAMItem(object):
         self.exclude_bad_copyright()
 
     def exclude_bad_copyright(self):
+        """Exclude images with non-free copyright."""
         bad_copyrights = ["by-nc-nd"]
         copyright = self.copyright or self.default_copyright
         if copyright.get("code") in bad_copyrights:

--- a/importer/make_glam_info.py
+++ b/importer/make_glam_info.py
@@ -537,6 +537,11 @@ class GLAMItem(object):
         :param with_depicted: whether to also include depicted data
         """
         language = self.glam_data.get("language")
+        if self.description is None:
+            if hasattr(self, "title"):
+                self.description = self.title
+            else:
+                self.description = ""
         desc = '{{%s|%s}}' % (language, self.description)
 
         if with_depicted:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/wikimedia/pywikibot-core.git
-git+https://github.com/lokal-profil/BatchUploadTools.git@0.2.2
+git+https://github.com/lokal-profil/BatchUploadTools.git@0.2.4

--- a/settings/settings.example.json
+++ b/settings/settings.example.json
@@ -1,6 +1,5 @@
 {
     "all_slides": "Bool on whether to harvest all slides of multi-slide objects or only 1st one",
-    "api_key": "YOUR API KEY",
     "batch_cat": "Stem for batch categories, eg 'Images from Nordiska museet'",
     "batch_date": "Batch date or other label to append to batch category stem, eg '2018-04'",
     "cutoff": "Int stating how many results to process, remove to process all",

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,5 +1,6 @@
 {
     "all_slides": true,
+    "api_key": "YOUR API KEY",
     "batch_cat": "Images from Nordiska museet",
     "batch_date": "2018-12",
     "cutoff": null,

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,0 +1,14 @@
+{
+    "all_slides": true,
+    "batch_cat": "Images from Nordiska museet",
+    "batch_date": "2018-12",
+    "cutoff": null,
+    "folder_id": "021097827596",
+    "glam_code": "S-NM",
+    "harvest_file": "nydrakt_harvest.json",
+    "harvest_log_file": "nydrakt_harvest.log",
+    "makeinfo_log_file": "nydrakt_makeinfo.log",
+    "mapping_log_file": "nydrakt_mapping.log",
+    "mappings_dir": "mappings",
+    "verbose": true
+}

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,6 +1,5 @@
 {
     "all_slides": true,
-    "api_key": "YOUR API KEY",
     "batch_cat": "Images from Nordiska museet",
     "batch_date": "2018-12",
     "cutoff": null,


### PR DESCRIPTION
Update script to upload `Nyfotograferad dräkt`.

Enhancements and bug fixes necessary for working with https://digitaltmuseum.se/021097827596

- Add cache step in Harvester. When downloading data from DiMu, the json response is saved in cache/ as one file per post. If Harvested is run with -cache:True, data is harvested from those files instead of from DiMu. Fixes #30.

- Sort harvester output by the GLAM code. Fixes #30.

- Remove API key from settings file. API key needs to provided at every run with -api_key flag. That way no sensitive data is stored in settings file. Fixes #32.

- Add settings.json to repository. As the API key is no longer stored there, we can track and share the file for easier set-up and cooperation.

- Handle objects without events. Fixes #28.

- Parse the alternative identifier `Insamlingsnr` and add it to the `original caption` field in the info template on Commons. Fixes #27.

- Use `title` to build file name if no `description` present.

- Handle objects without photographer.

- Add images with non-free copyright (by-nc-nd) to the problem list in make_glam_info.

- Use BatchUploadTools version 0.2.4